### PR TITLE
Remove merge carnival from config

### DIFF
--- a/branches-in-git/activity-merge-carnival.instructor.md
+++ b/branches-in-git/activity-merge-carnival.instructor.md
@@ -1,5 +1,7 @@
 # Instructor: Activity: Merge Carnival
 
+**Currently in core-industry-prep repo/unit. Topic: Industry Prep Fridays**
+
 Breakout Room number/assignments may need to be adjusted depending on size of class.
 
 In C16 this activity was done during Industry Prep Fridays

--- a/branches-in-git/activity-merge-carnival.md
+++ b/branches-in-git/activity-merge-carnival.md
@@ -1,8 +1,11 @@
+
 # Activity: Merge Carnival
+
+**Currently in core-industry-prep repo/unit. Topic: Industry Prep Fridays**
 
 ## Goals
 
 The goal of this activity is to introduce and practice using branches and pull requests for collaborating with Git and GitHub.
 
 ## Activity Repository
-[https://github.com/AdaGold/carnival-recipes](https://github.com/ada-c17/carnival-recipes)
+[https://github.com/ada-c17/carnival-recipes](https://github.com/ada-c17/carnival-recipes)

--- a/config.yaml
+++ b/config.yaml
@@ -90,15 +90,11 @@ Standards:
         Path: /intro-to-git/problem-set-git-commands.md
   -
     Title: Branches In Git
-    Description: "Branches, Using Branches in Git, Problem Set: Git, Activity: Merge Carnival"
+    Description: "Branches, Using Branches in Git, Problem Set: Git"
     UID: 76a4001e9bc2734c2e93ede4b8f1297e
     SuccessCriteria:
       - success criteria
     ContentFiles:
-      -
-        Type: Instructor
-        UID: bfe2e5a6-7731-44a5-9beb-e7b0e387954e
-        Path: /branches-in-git/activity-merge-carnival.instructor.md
       -
         Type: Lesson
         UID: 6c8aa01cc55f51f3cb90f1fd9f851595
@@ -111,10 +107,6 @@ Standards:
         Type: Lesson
         UID: a23c8692ae7b601177cd574151717d51
         Path: /branches-in-git/problem-set-git.md
-      -
-        Type: Lesson
-        UID: c421363b-ef64-4017-9e90-25ca0ba14f79
-        Path: /branches-in-git/activity-merge-carnival.md
   -
     Title: "External Resources"
     Description: "Learning Resources Provided by the Ada Community"


### PR DESCRIPTION
This content was moved to core-industry-prep -> Industry Prep Fridays. I left the files here and just removed them from the config for ease of reorganization at a later date